### PR TITLE
Add appSize, apkSize, dataSize and cacheSize to Application list columns

### DIFF
--- a/src/renderer/main/components/application/Application.tsx
+++ b/src/renderer/main/components/application/Application.tsx
@@ -35,6 +35,7 @@ import dateFormat from 'licia/dateFormat'
 import toEl from 'licia/toEl'
 import DataGrid from 'luna-data-grid'
 import { useWindowResize } from 'share/renderer/lib/hooks'
+import fileSize from 'licia/fileSize'
 
 export default observer(function Application() {
   const [isLoading, setIsLoading] = useState(false)
@@ -323,6 +324,10 @@ export default observer(function Application() {
               packageName: info.packageName,
               versionName: info.versionName,
               minSdkVersion: info.minSdkVersion,
+              apkSize: fileSize(info.apkSize),
+              appSize: fileSize(info.appSize || 0),
+              dataSize: fileSize(info.dataSize || 0),
+              cacheSize: fileSize(info.cacheSize || 0),
               targetSdkVersion: info.targetSdkVersion,
               enabled: info.enabled ? t('enabled') : t('disabled'),
               lastUpdateTime: dateFormat(
@@ -522,5 +527,29 @@ const columns = [
     title: t('lastUpdateTime'),
     sortable: true,
     weight: 15,
+  },
+  {
+    id: 'apkSize',
+    title: t('apkSize'),
+    sortable: true,
+    weight: 10,
+  },
+  {
+    id: 'appSize',
+    title: t('appSize'),
+    sortable: true,
+    weight: 10,
+  },
+  {
+    id: 'dataSize',
+    title: t('dataSize'),
+    sortable: true,
+    weight: 10,
+  },
+  {
+    id: 'cacheSize',
+    title: t('cacheSize'),
+    sortable: true,
+    weight: 10,
   },
 ]


### PR DESCRIPTION
I could not test because I cannot run the dev environment on windows with zx forcing `/bin/bash` on my configuration. 

Would also probably be a good idea to add a menu (on right-click of the table list title bar) which would be a selectable list of column names, to let users chose which columns to display like on windows file explorer. 