### PR TITLE
Push updated releases to winget-pkgs

### DIFF
--- a/.github/workflows/winget-releaser.yml
+++ b/.github/workflows/winget-releaser.yml
@@ -1,0 +1,13 @@
+name: Publish release to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@main
+        with:
+          identifier: LiriLiri.AYA
+          installers-regex: 'AYA-*-win-x64\.exe'
+          token: ${{ secrets.WINGET_ACC_TOKEN }}


### PR DESCRIPTION
This PR uses [winget-releaser](https://github.com/vedantmgoyal9/winget-releaser) (which uses Komac). It requires a `Classic Github Personal Access Token` with `public_repo` scope is created, following [this link](https://github.com/settings/tokens/new), then the Token can be added to the repo as a secret named `WINGET_ACC_TOKEN`. See below, that user also will have to fork the winget-pkgs repository.

> Notes:
> You will need to create a *classic* Personal Access Token (PAT) with `public_repo` scope. New fine-grained PATs aren't supported by the action. Review #172 for information.
> Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under the same account/organization as the project's repository. If you are forking winget-pkgs on a different account (e.g. bot/personal account), you can use the fork-user input to specify the username of the account where the fork is present.
