### PR TITLE
feat: Add support for uninstalling packages for user 0 (system user)

### DIFF
--- a/src/common/langs/en-US.json
+++ b/src/common/langs/en-US.json
@@ -57,6 +57,8 @@
   "installPackageErr": "Failed to install package",
   "uninstall": "Uninstall",
   "uninstallConfirm": "Are you sure you want to uninstall {{name}}?",
+  "uninstallUser0": "Uninstall User 0",
+  "uninstallUser0Confirm": "Are you sure you want to uninstall {{name}} for user 0 (the system user)?",
   "clearData": "Clear Data",
   "clearDataConfirm": "Are you sure you want to clear data for {{name}}?",
   "dataCleared": "Data cleared",

--- a/src/main/lib/adb/package.ts
+++ b/src/main/lib/adb/package.ts
@@ -65,6 +65,11 @@ const uninstallPackage: IpcUninstallPackage = async function (deviceId, pkg) {
   await device.uninstall(pkg)
 }
 
+const uninstallUser0Package: IpcUninstallPackage = async function (deviceId, pkg) {
+  const device = await client.getDevice(deviceId)
+  await device.uninstall(`--user 0 ${pkg}`)
+}
+
 async function getMainComponent(deviceId: string, pkg: string) {
   const result = await shell(
     deviceId,
@@ -131,6 +136,7 @@ export async function init(c: Client) {
   handleEvent('startPackage', startPackage)
   handleEvent('installPackage', installPackage)
   handleEvent('uninstallPackage', uninstallPackage)
+  handleEvent('uninstallUser0Package', uninstallUser0Package)
   handleEvent('getTopPackage', getTopPackage)
   handleEvent('clearPackage', clearPackage)
   handleEvent('disablePackage', disablePackage)

--- a/src/preload/main.ts
+++ b/src/preload/main.ts
@@ -92,6 +92,7 @@ export default Object.assign(mainObj, {
   startPackage: invoke<IpcStartPackage>('startPackage'),
   installPackage: invoke<IpcInstallPackage>('installPackage'),
   uninstallPackage: invoke<IpcUninstallPackage>('uninstallPackage'),
+  uninstallUser0Package: invoke<IpcUninstallPackage>('uninstallUser0Package'),
   getPackages: invoke<IpcGetPackages>('getPackages'),
   getPackageInfos: invoke<IpcGetPackageInfos>('getPackageInfos'),
   disablePackage: invoke<IpcDisablePackage>('disablePackage'),

--- a/src/renderer/main/components/application/Application.tsx
+++ b/src/renderer/main/components/application/Application.tsx
@@ -272,6 +272,18 @@ export default observer(function Application() {
           }
         },
       },
+      {
+        label: t('uninstallUser0'),
+        click: async () => {
+          const result = await LunaModal.confirm(
+            confirmText('uninstallUser0Confirm', info)
+          )
+          if (result) {
+            await main.uninstallUser0Package(device.id, info.packageName)
+            refresh()
+          }
+        },
+      },
     ]
 
     contextMenu(e, template)


### PR DESCRIPTION
## Summary
This PR adds the ability to uninstall Android packages for user 0 (the system user) through the application interface. This feature is particularly useful for disabling bloatware that cannot be removed through standard uninstall methods.

## Changes
- Added new translation strings for "Uninstall User 0" action and confirmation dialog
- Implemented `uninstallUser0Package` IPC handler that uses `--user 0` flag with ADB uninstall command
- Exposed the new function in the preload script for renderer process access
- Added context menu option in Application component to trigger user 0 uninstall

## Technical Details
The implementation follows the existing uninstall pattern but adds the `--user 0` parameter to target the system user specifically. The `--user 0` flag is particularly useful for disabling bloatware applications that are installed as system apps and cannot be removed through normal uninstall procedures. This allows users to effectively disable unwanted pre-installed applications on their Android devices.


## Files Changed
- `src/common/langs/en-US.json` - Added translation strings
- `src/main/lib/adb/package.ts` - Added `uninstallUser0Package` handler
- `src/preload/main.ts` - Exposed new IPC function
- `src/renderer/main/components/application/Application.tsx` - Added UI option

## Testing
- [x] Verify uninstall for user 0 works correctly
- [x] Confirm confirmation dialog displays properly
- [x] Test that regular uninstall still works as expected